### PR TITLE
fix: revert align MCAF provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Terraform module for a disk encryption set
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.30 |
 
 ## Modules
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0.0"
+      version = "~> 4.30"
     }
   }
 }


### PR DESCRIPTION
Reverts schubergphilis/terraform-azure-mcaf-diskencryptionset#5

Reverting as `~> 4.0.0` only allows `>= 4.0.0, < 4.1.0` or `4.0.x` provider versions. This is not intended. Reverting back to `~> 4.30` as that allows `>= 4.30, < 5.0`, or `4.x` (all minors, but starting from 4.30). 